### PR TITLE
Allow router.use to accept callbacks

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -126,6 +126,7 @@ module.exports = function router()
     router.use = function(path, subRouter)
     {
         subRouter.basePath = (router.basePath ? router.basePath : "") + path;
+        subRouter.isRouter = true;
         this.all(path, subRouter);
     };
 


### PR DESCRIPTION
Currently router.use requires a Router instance to function correctly.

This PR allows router.use to support `(req, res, next) => { next(); }` function callbacks.